### PR TITLE
Update deployer script, minor bugfixes

### DIFF
--- a/deployer/src/app.py
+++ b/deployer/src/app.py
@@ -31,13 +31,17 @@ def wait_for_frontend():
     """Wait for OISP frontend hearbeat."""
     kafka_server = os.environ["KAFKA"]
     heartbeat_topic = os.environ["KAFKA_HEARTBEAT_TOPIC"]
-
+    print("Connecting to kafka at {}, topic: {} ".format(kafka_server, heartbeat_topic))
     for _ in range(KAFKA_BROKER_TIMEOUT):
         try:
             consumer = kafka.KafkaConsumer(heartbeat_topic, bootstrap_servers=kafka_server,
                                            auto_offset_reset='latest')
+            break
         except kafka.errors.NoBrokersAvailable:
+            print("No kafka brokers available, trying again")
             time.sleep(1)
+
+    print("Connected to kafka")
 
     for message in consumer:
         # Frontend heartbeat message is dashboard for historical reasons

--- a/deployer/src/vcap.py
+++ b/deployer/src/vcap.py
@@ -66,7 +66,7 @@ class VcapServices(Vcap):
             .replace("http://", "") \
             .replace("https://", "") \
             .replace("-", "_") \
-            .replace(".", "_")
+            .replace(".", "_").split(":")[0]
 
     def __gather_topics_names(self, ups):
         kafka_ups = self.__get_ups_by_name(ups, 'kafka-ups')


### PR DESCRIPTION
Script used to reconnect to kafka even after succesful connection.
Gearpump app name was not normalized correctly if dashboard adress contained explicit port number.